### PR TITLE
use express router instead of app

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ var asArray = function(value) {
 
 
 module.exports = function(robots) {
-  var app = require('express')();
+  var router = require('express').Router();
 
   if(robots) {
     robots = 'string' === typeof robots
@@ -26,12 +26,12 @@ module.exports = function(robots) {
   } else
     robots = '';
 
-  app.get('/robots.txt', function(req, res) {
+  router.get('/robots.txt', function(req, res) {
     res.header('Content-Type', 'text/plain');
     res.send(robots);
   });
 
-  return app;
+  return router;
 };
 
 function render(robots) {


### PR DESCRIPTION
when you use express `app` this will override some express settings such as `app.disable('x-powered-by')`